### PR TITLE
Adjust rainbow field band styling and multi-touch handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1088,7 +1088,7 @@ const playTapSound = (
     y,
     cell.frequency,
     cell.color,
-    1100
+    200
   );
 };
 
@@ -1288,6 +1288,8 @@ export default function App() {
 
   const handlePointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+
       const container = containerRef.current;
       const meta = pointerMetaRef.current.get(event.pointerId);
       if (!container || !meta) {


### PR DESCRIPTION
## Summary
- remove the center artifact and add alternating saturated bands to the rainbow ripple
- shorten ripple release and pulse durations for a much faster fade-out
- prevent default pointer moves to improve multi-touch stability during interaction

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e48095d43483328f1083d38aa64909